### PR TITLE
links to mirrors now include rel attribute

### DIFF
--- a/netselect-apt
+++ b/netselect-apt
@@ -56,7 +56,7 @@ run_netselect()
               if( ( /Includes architectures:.+'"$arch"'.+/i ||
                     $_ !~ /Includes architectures:/
                   ) &&
-                    m@'"$SEARCH"':.*<a href="('"$PROTO"'://.*?)">@i ){
+                    m@'"$SEARCH"':.*<a rel="nofollow" href="('"$PROTO"'://.*?)">@i ){
                     print("$1\n"); 
               }
             }') \


### PR DESCRIPTION
Added:

rel="nofollow"

attribute to anchor tags to account for the new format from http://www.debian.org/mirror/list-full
