### PR TITLE
Update netselect-apt

### DIFF
--- a/netselect-apt
+++ b/netselect-apt
@@ -33,7 +33,7 @@ infile="mirrors_full"
 outfile="sources.list"
 distro="stable"
 protocol="HTTP"
-url="http://www.debian.org/mirror/mirrors_full"
+url="http://www.debian.org/mirror/list"
 arch=$(/usr/bin/dpkg --print-architecture)
 
 options="-o a:si:o:nfhu -l arch:,sources,infile:,outfile:,nonfree,ftp,nonus,help"


### PR DESCRIPTION
The url has changed. The url that was originally in the code was 'url="http://www.debian.org/mirror/mirrors_full"'. I changed it to 'url="http://www.debian.org/mirror/list"'. I made this change as on running wget encountered a 404 error.
